### PR TITLE
Task.Interrupt mistakes error for success in windows

### DIFF
--- a/task/task_windows.go
+++ b/task/task_windows.go
@@ -28,7 +28,7 @@ func getPgID(cmd *exec.Cmd) (int, error) {
 func (t *Task) Interrupt() error {
 	log.VV("Requested Ctrl-Break on task")
 	r, _, err := procGenerateConsoleCtrlEvent.Call(syscall.CTRL_BREAK_EVENT, uintptr(t.pgid))
-	if r != 0 {
+	if r == 0 {
 		return fmt.Errorf("r = %v err: %v", r, err)
 	}
 	return nil


### PR DESCRIPTION
The reason is that GenerateConsoleCtrlEvent returns a nonzero value on success.
See [MSDN](https://msdn.microsoft.com/library/windows/desktop/ms683155%28v=vs.85%29.aspx)
